### PR TITLE
Add xunit tests project

### DIFF
--- a/Earthquake.Tests/Earthquake.Tests.csproj
+++ b/Earthquake.Tests/Earthquake.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.19" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Earthquake\EarthquakeMap.csproj" />
+  </ItemGroup>
+</Project>

--- a/Earthquake.Tests/Tests/MainWindowTests.cs
+++ b/Earthquake.Tests/Tests/MainWindowTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows;
+using System.Windows.Media.Imaging;
+using Moq;
+using Moq.Protected;
+using QuakeData;
+using EarthQuake;
+using Xunit;
+
+namespace Earthquake.Tests
+{
+    public class MainWindowTests
+    {
+        private MainWindow CreateWindow()
+        {
+            var window = new MainWindow();
+            // initialize components are not called in tests
+            window.imgMap = new Image { Width = 360, Height = 180, Margin = new Thickness(0) };
+            window.dpStart = new DatePicker();
+            window.dpEnd = new DatePicker();
+            window.cbMagnitude = new ComboBox();
+            return window;
+        }
+
+        [Fact]
+        public void UrlBuilder_SameDay_GeneratesMinimalUrl()
+        {
+            var window = CreateWindow();
+            window.dpStart.SelectedDate = new DateTime(2020, 1, 1);
+            window.dpEnd.SelectedDate = new DateTime(2020, 1, 1);
+            window.cbMagnitude.Text = "3";
+
+            var url = window.urlBuilder();
+            Assert.Contains("starttime=2020-01-01", url);
+            Assert.DoesNotContain("endtime", url);
+        }
+
+        [Fact]
+        public void UrlBuilder_Range_GeneratesFullUrl()
+        {
+            var window = CreateWindow();
+            window.dpStart.SelectedDate = new DateTime(2020, 1, 1);
+            window.dpEnd.SelectedDate = new DateTime(2020, 1, 2);
+            window.cbMagnitude.Text = "2";
+
+            var url = window.urlBuilder();
+            Assert.Contains("starttime=2020-01-01", url);
+            Assert.Contains("endtime=2020-01-02", url);
+            Assert.Contains("minmagnitude=2", url);
+        }
+
+        [Fact]
+        public void ToMercator_MapsCoordinates()
+        {
+            var window = CreateWindow();
+            var point = window.ToMercator(new List<double> { 0, 0, 0 });
+            Assert.Equal(180, point.X, 1);
+            Assert.Equal(90, point.Y, 1);
+        }
+
+        [Fact]
+        public void GetQuake_TransformsFeaturesToDictionary()
+        {
+            var window = CreateWindow();
+            var root = new RootObject
+            {
+                features = new List<Feature>
+                {
+                    new Feature
+                    {
+                        geometry = new Geometry { coordinates = new List<double>{0,0,0} },
+                        properties = new Properties { place = "x", mag = 1, felt = 2, tsunami = 0 }
+                    }
+                }
+            };
+            typeof(MainWindow).GetField("root", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .SetValue(window, root);
+            var dict = window.getQuake();
+            Assert.Single(dict);
+        }
+
+        [Fact]
+        public async Task GetDataAsync_ParsesJson()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"features\":[],\"metadata\":{}}")
+                });
+
+            var client = new HttpClient(handler.Object);
+            var window = CreateWindow();
+            typeof(MainWindow).GetField("httpClient", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!
+                .SetValue(null, client);
+
+            var result = await window.GetDataAsync("http://example");
+            Assert.NotNull(result);
+            Assert.Empty(result.features);
+        }
+    }
+}

--- a/Earthquake.sln
+++ b/Earthquake.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Express 2012 for Windows Desktop
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EarthquakeMap", "Earthquake\EarthquakeMap.csproj", "{0C03CB1C-A32A-4CB2-B886-60488190FDD1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Earthquake.Tests", "Earthquake.Tests\Earthquake.Tests.csproj", "{B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,7 +27,20 @@ Global
 		{0C03CB1C-A32A-4CB2-B886-60488190FDD1}.Release|x64.ActiveCfg = Release|x64
 		{0C03CB1C-A32A-4CB2-B886-60488190FDD1}.Release|x64.Build.0 = Release|x64
 		{0C03CB1C-A32A-4CB2-B886-60488190FDD1}.Release|x86.ActiveCfg = Release|x86
-		{0C03CB1C-A32A-4CB2-B886-60488190FDD1}.Release|x86.Build.0 = Release|x86
+               {0C03CB1C-A32A-4CB2-B886-60488190FDD1}.Release|x86.Build.0 = Release|x86
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Debug|x64.ActiveCfg = Debug|x64
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Debug|x64.Build.0 = Debug|x64
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Debug|x86.ActiveCfg = Debug|x86
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Debug|x86.Build.0 = Debug|x86
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Release|Any CPU.ActiveCfg = Release|x64
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Release|Any CPU.Build.0 = Release|x64
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Release|Any CPU.Deploy.0 = Release|x64
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Release|x64.ActiveCfg = Release|x64
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Release|x64.Build.0 = Release|x64
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Release|x86.ActiveCfg = Release|x86
+                {B1E0FBDE-73E6-4BD8-A57A-D51FBBF3F2BD}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add a new xUnit project with references to the main WPF app
- create `MainWindowTests` verifying URL generation, coordinate conversion and data parsing
- register the test project in the solution

## Testing
- `dotnet test Earthquake.Tests/Earthquake.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870ece1d5188326a0b53220487473b4